### PR TITLE
Add stubs for documentation

### DIFF
--- a/docs/analog.md
+++ b/docs/analog.md
@@ -1,0 +1,16 @@
+Analog Inputs
+=============
+_NB: this refers to general purpose analog inputs for things like CLT, TPS, MAP, etc.  High-speed inputs like triggers and knock have their own pages at [trigger](docs/design/trigger.md) and [knock](docs/design/knock.md)_
+
+## What do the analog inputs support? ##
+- 16 channels
+- 0-5v input
+- No input protection, other than 1k series resistor
+
+## How do the analog inputs work? ##
+- 16 channels are managed by 4 MCP6004 quad op-amps.
+- 1k + 1nf RC filter input to opamp non-inverting input.  This gives approximately 160khz of bandwidth.  If a lower knee is desired, additional circuitry can be added (series resistor, or another RC, etc) to the vehicle adapter.
+- Dual 1.5k resistor divider on the output, scaling 0-5v input to 0-2.5v output.  The input impedance of the STM32's ADC is on the order of 6k, so the exact value chosen does not appreciably alter the response of the system.
+
+## What do the analog inputs NOT do? ##
+- Input protection: this is highly pin specific, and may not be wanted if the signal is coming from the vehicle adapter board.  Appropriate larger series resistor and TVS diodes recommended.

--- a/docs/knock.md
+++ b/docs/knock.md
@@ -1,0 +1,2 @@
+Knock Sensor Inputs
+===================

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -1,0 +1,2 @@
+Outputs (injector, low side, and push-pull)
+===========================================

--- a/docs/power.md
+++ b/docs/power.md
@@ -1,0 +1,2 @@
+Power Supplies
+==============

--- a/docs/trigger.md
+++ b/docs/trigger.md
@@ -1,0 +1,2 @@
+Trigger (Hall & VR) Inputs
+==========================


### PR DESCRIPTION
The "what is the actual plan" should live alongside the implementation.  These are not intended for user documentation, but for us to reference while developing the hardware and software.  That's why they live alongside the design: change the design and docs together, so they can be looked at together in previous iterations.